### PR TITLE
Adds In Dblog

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -42,5 +42,10 @@
     "name": "Leo Finance",
     "homepage": "https://leofinance.io",
     "url_scheme": "https://leofinance.io/{category}/@{username}/{permlink}"
+  },
+  "dblog": {
+    "name": "Dblog",
+    "homepage": "https://dblog.org/",
+    "url_scheme": "https://{domain}/{permlink}"
   }
 }

--- a/apps.json
+++ b/apps.json
@@ -43,7 +43,7 @@
     "homepage": "https://leofinance.io",
     "url_scheme": "https://leofinance.io/{category}/@{username}/{permlink}"
   },
-  "dblog": {
+  "engrave": {
     "name": "Dblog",
     "homepage": "https://dblog.org/",
     "url_scheme": "https://{domain}/{permlink}"


### PR DESCRIPTION
Here's an example of a dblog post on the block explorer : https://hiveblocks.com/engrave/@rishi556/welcome-to-my-blog. 

Same post on their blog: https://rishi.dblog.org/welcome-to-my-blog.

In the metadata, there's a key `engrave` with value 
```
{"domain":"rishi.dblog.org","permlink":"welcome-to-my-blog"}
```

Frontends can pretty easily pull the domain from the metadata, but will require additional work by the frontends.