### PR TITLE
add beempy

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -42,5 +42,10 @@
     "name": "Leo Finance",
     "homepage": "https://leofinance.io",
     "url_scheme": "https://leofinance.io/{category}/@{username}/{permlink}"
+  },
+    "beempy": {
+    "name": "beempy",
+    "homepage": "https://hive.blog",
+    "url_scheme": "https://hive.blog/{category}/@{username}/{permlink}"
   }
 }

--- a/apps.json
+++ b/apps.json
@@ -43,7 +43,7 @@
     "homepage": "https://leofinance.io",
     "url_scheme": "https://leofinance.io/{category}/@{username}/{permlink}"
   },
-    "beempy": {
+  "beempy": {
     "name": "beempy",
     "homepage": "https://hive.blog",
     "url_scheme": "https://hive.blog/{category}/@{username}/{permlink}"

--- a/apps.json
+++ b/apps.json
@@ -45,7 +45,6 @@
   },
   "beempy": {
     "name": "beempy",
-    "homepage": "https://hive.blog",
-    "url_scheme": "https://hive.blog/{category}/@{username}/{permlink}"
+    "homepage": "https://github.com/holgern/beem",
   }
 }


### PR DESCRIPTION
Example post: https://hive.blog/hive-139531/@holger80/hivediff---an-app-to-view-the-history-of-any-hive-post

Adding beempy, so that it can be used with `canonical_url`